### PR TITLE
feat(): fix concurrent map access in cache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -91,7 +91,12 @@ func (c *Cache) UpdateFee(price schema.ArFee) {
 func (c *Cache) GetPeerMap() map[string]int64 {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.peerMap
+	peerMap := make(map[string]int64)
+	for peerIp, count := range c.peerMap {
+		peerMap[peerIp] = count
+	}
+
+	return peerMap
 }
 
 func (c *Cache) GetPeers() []string {

--- a/jobs.go
+++ b/jobs.go
@@ -91,7 +91,7 @@ func (s *Arseeding) updatePeerMap() {
 	peerMap := updatePeerMap(s.cache.GetPeerMap(), availablePeers)
 
 	s.cache.UpdatePeers(peerMap)
-	if err = s.store.SavePeers(peerMap); err != nil {
+	if err = s.store.SavePeers(s.cache.GetPeerMap()); err != nil {
 		log.Warn("save new peer list fail")
 	}
 }


### PR DESCRIPTION
Reading and writing the map without locking caused a crash.
https://github.com/everFinance/arseeding/blob/4292997f799d94c4457a96086b372227ab46bb29/jobs.go#L729
```
{"log":"fatal error: concurrent map iteration and map write\n","stream":"stderr","time":"2023-02-23T23:16:17.503592993Z"}
{"log":"\n","stream":"stderr","time":"2023-02-23T23:16:17.50676632Z"}
{"log":"goroutine 116868729 [running]:\n","stream":"stderr","time":"2023-02-23T23:16:17.506782709Z"}
{"log":"runtime.throw({0xf8228b?, 0xc00?})\n","stream":"stderr","time":"2023-02-23T23:16:17.506786961Z"}
{"log":"\u0009/usr/local/go/src/runtime/panic.go:992 +0x71 fp=0xc000a21308 sp=0xc000a212d8 pc=0x437411\n","stream":"stderr","time":"2023-02-23T23:16:17.506802009Z"}
{"log":"runtime.mapiternext(0xc000a21480?)\n","stream":"stderr","time":"2023-02-23T23:16:17.506807788Z"}
{"log":"\u0009/usr/local/go/src/runtime/map.go:871 +0x4eb fp=0xc000a21378 sp=0xc000a21308 pc=0x40fe8b\n","stream":"stderr","time":"2023-02-23T23:16:17.506811753Z"}
{"log":"github.com/everFinance/arseeding.(*Cache).GetPeers(0xc0001892c0)\n","stream":"stderr","time":"2023-02-23T23:16:17.506815935Z"}
{"log":"\u0009/arseeding/cache.go:101 +0x145 fp=0xc000a214f8 sp=0xc000a21378 pc=0xcfffc5\n","stream":"stderr","time":"2023-02-23T23:16:17.506819897Z"}
{"log":"github.com/everFinance/arseeding.(*Arseeding).updateInfo(0xc0005be840)\n","stream":"stderr","time":"2023-02-23T23:16:17.506824376Z"}
{"log":"\u0009/arseeding/jobs.go:66 +0x3a fp=0xc000a215c0 sp=0xc000a214f8 pc=0xd0199a\n","stream":"stderr","time":"2023-02-23T23:16:17.506828776Z"}
{"log":"github.com/everFinance/arseeding.(*Arseeding).updateInfo-fm()\n","stream":"stderr","time":"2023-02-23T23:16:17.506833151Z"}
{"log":"\u0009\u003cautogenerated\u003e:1 +0x26 fp=0xc000a215d8 sp=0xc000a215c0 pc=0xd18f46\n","stream":"stderr","time":"2023-02-23T23:16:17.50683742Z"}
{"log":"runtime.call16(0xc0003f8240, 0xc0001c6380, 0x0, 0x0, 0x0, 0x0, 0xc000a21b08)\n","stream":"stderr","time":"2023-02-23T23:16:17.506857425Z"}
{"log":"\u0009/usr/local/go/src/runtime/asm_amd64.s:701 +0x49 fp=0xc000a215f8 sp=0xc000a215d8 pc=0x465a49\n","stream":"stderr","time":"2023-02-23T23:16:17.506870075Z"}
{"log":"runtime.reflectcall(0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?, 0x0?)\n","stream":"stderr","time":"2023-02-23T23:16:17.506895471Z"}
{"log":"\u0009\u003cautogenerated\u003e:1 +0x3c fp=0xc000a21638 sp=0xc000a215f8 pc=0x469dfc\n","stream":"stderr","time":"2023-02-23T23:16:17.506912762Z"}
{"log":"reflect.Value.call({0xdd2840?, 0xc0001c6380?, 0xc00029e1e7?}, {0xf577a9, 0x4}, {0x183b4a8, 0x0, 0x1?})\n","stream":"stderr","time":"2023-02-23T23:16:17.506949009Z"}
{"log":"\u0009/usr/local/go/src/reflect/value.go:556 +0x845 fp=0xc000a21c28 sp=0xc000a21638 pc=0x497785\n","stream":"stderr","time":"2023-02-23T23:16:17.506960251Z"}
{"log":"reflect.Value.Call({0xdd2840?, 0xc0001c6380?, 0xc00043e0c0?}, {0x183b4a8, 0x0, 0x0})\n","stream":"stderr","time":"2023-02-23T23:16:17.506990727Z"}
{"log":"\u0009/usr/local/go/src/reflect/value.go:339 +0xbf fp=0xc000a21ca0 sp=0xc000a21c28 pc=0x496cff\n","stream":"stderr","time":"2023-02-23T23:16:17.506999737Z"}
{"log":"github.com/go-co-op/gocron.callJobFuncWithParams({0xdd2840?, 0xc0001c6380?}, {0x0, 0x0, 0x203000?})\n","stream":"stderr","time":"2023-02-23T23:16:17.507024211Z"}
{"log":"\u0009/go/pkg/mod/github.com/go-co-op/gocron@v1.11.0/gocron.go:78 +0x135 fp=0xc000a21d18 sp=0xc000a21ca0 pc=0xa6aa35\n","stream":"stderr","time":"2023-02-23T23:16:17.507056124Z"}
{"log":"github.com/go-co-op/gocron.(*executor).start.func1.1()\n","stream":"stderr","time":"2023-02-23T23:16:17.507060516Z"}
{"log":"\u0009/go/pkg/mod/github.com/go-co-op/gocron@v1.11.0/executor.go:94 +0xe9 fp=0xc000a21d90 sp=0xc000a21d18 pc=0xa6a7e9\n","stream":"stderr","time":"2023-02-23T23:16:17.507064027Z"}
{"log":"golang.org/x/sync/singleflight.(*Group).doCall.func2(0xc000a21de6, 0xc0006d6f60, 0x60?)\n","stream":"stderr","time":"2023-02-23T23:16:17.507072302Z"}
{"log":"\u0009/go/pkg/mod/golang.org/x/sync@v0.0.0-20220722155255-886fb9371eb4/singleflight/singleflight.go:193 +0x6f fp=0xc000a21dc8 sp=0xc000a21d90 pc=0xa69a8f\n","stream":"stderr","time":"2023-02-23T23:16:17.507082332Z"}
{"log":"golang.org/x/sync/singleflight.(*Group).doCall(0xe2f780?, 0xc0007b3380?, {0xf57d51?, 0x4?}, 0x4d178?)\n","stream":"stderr","time":"2023-02-23T23:16:17.507211721Z"}
{"log":"\u0009/go/pkg/mod/golang.org/x/sync@v0.0.0-20220722155255-886fb9371eb4/singleflight/singleflight.go:195 +0xa5 fp=0xc000a21e38 sp=0xc000a21dc8 pc=0xa699a5\n","stream":"stderr","time":"2023-02-23T23:16:17.507216392Z"}
{"log":"golang.org/x/sync/singleflight.(*Group).Do(0xc0001c6360, {0xf57d51, 0x4}, 0xa6ae60?)\n","stream":"stderr","time":"2023-02-23T23:16:17.507219185Z"}
{"log":"\u0009/go/pkg/mod/golang.org/x/sync@v0.0.0-20220722155255-886fb9371eb4/singleflight/singleflight.go:108 +0x154 fp=0xc000a21e88 sp=0xc000a21e38 pc=0xa697f4\n","stream":"stderr","time":"2023-02-23T23:16:17.507222451Z"}
{"log":"github.com/go-co-op/gocron.(*executor).start.func1()\n","stream":"stderr","time":"2023-02-23T23:16:17.507225769Z"}
{"log":"\u0009/go/pkg/mod/github.com/go-co-op/gocron@v1.11.0/executor.go:85 +0x1da fp=0xc000a21fe0 sp=0xc000a21e88 pc=0xa6a53a\n","stream":"stderr","time":"2023-02-23T23:16:17.507229236Z"}
{"log":"runtime.goexit()\n","stream":"stderr","time":"2023-02-23T23:16:17.507233217Z"}
{"log":"\u0009/usr/local/go/src/runtime/asm_amd64.s:1571 +0x1 fp=0xc000a21fe8 sp=0xc000a21fe0 pc=0x4675e1\n","stream":"stderr","time":"2023-02-23T23:16:17.507236626Z"}
{"log":"created by github.com/go-co-op/gocron.(*executor).start\n","stream":"stderr","time":"2023-02-23T23:16:17.507240234Z"}
{"log":"\u0009/go/pkg/mod/github.com/go-co-op/gocron@v1.11.0/executor.go:50 +0x71\n","stream":"stderr","time":"2023-02-23T23:16:17.507243883Z"}
{"log":"\n","stream":"stderr","time":"2023-02-23T23:16:17.507247654Z"}
{"log":"goroutine 1 [chan receive, 72682 minutes]:\n","stream":"stderr","time":"2023-02-23T23:16:17.507250918Z"}
{"log":"main.run(0xc000180000?)\n","stream":"stderr","time":"2023-02-23T23:16:17.507280408Z"}
{"log":"\u0009/arseeding/cmd/main.go:78 +0x768\n","stream":"stderr","time":"2023-02-23T23:16:17.507285552Z"}
{"log":"github.com/urfave/cli/v2.(*App).RunContext(0xc0000829c0, {0x11df3e0?, 0xc000038090}, {0xc000030230, 0x1, 0x1})\n","stream":"stderr","time":"2023-02-23T23:16:17.507289367Z"}
{"log":"\u0009/go/pkg/mod/github.com/urfave/cli/v2@v2.10.2/app.go:350 +0x9d3\n","stream":"stderr","time":"2023-02-23T23:16:17.507292954Z"}
{"log":"github.com/urfave/cli/v2.(*App).Run(...)\n","stream":"stderr","time":"2023-02-23T23:16:17.507296167Z"}
{"log":"\u0009/go/pkg/mod/github.com/urfave/cli/v2@v2.10.2/app.go:247\n","stream":"stderr","time":"2023-02-23T23:16:17.507298773Z"}
{"log":"main.main()\n","stream":"stderr","time":"2023-02-23T23:16:17.507305011Z"}
{"log":"\u0009/arseeding/cmd/main.go:46 +0xfb9\n","stream":"stderr","time":"2023-02-23T23:16:17.50730746Z"}
{"log":"\n","stream":"stderr","time":"2023-02-23T23:16:17.507330588Z"}
{"log":"goroutine 7 [select]:\n","stream":"stderr","time":"2023-02-23T23:16:17.507336385Z"}
{"log":"github.com/panjf2000/ants/v2.(*Pool).purgePeriodically(0xc000492080, {0x11df3a8, 0xc0000a0140})\n","stream":"stderr","time":"2023-02-23T23:16:17.507339439Z"}
{"log":"\u0009/go/pkg/mod/github.com/panjf2000/ants/v2@v2.6.0/pool.go:78 +0x116\n","stream":"stderr","time":"2023-02-23T23:16:17.507342938Z"}
{"log":"created by github.com/panjf2000/ants/v2.NewPool\n","stream":"stderr","time":"2023-02-23T23:16:17.507346209Z"}
{"log":"\u0009/go/pkg/mod/github.com/panjf2000/ants/v2@v2.6.0/pool.go:157 +0x3c5\n","stream":"stderr","time":"2023-02-23T23:16:17.507350765Z"}
{"log":"\n","stream":"stderr","time":"2023-02-23T23:16:17.507355215Z"}
{"log":"goroutine 51 [syscall, 72682 minutes]:\n","stream":"stderr","time":"2023-02-23T23:16:17.50735886Z"}
{"log":"os/signal.signal_recv()\n","stream":"stderr","time":"2023-02-23T23:16:17.507368275Z"}
{"log":"\u0009/usr/local/go/src/runtime/sigqueue.go:151 +0x2f\n","stream":"stderr","time":"2023-02-23T23:16:17.507372491Z"}
```